### PR TITLE
Improve vehicle ID parsing and brace matching

### DIFF
--- a/ets2-tool/src-tauri/Cargo.lock
+++ b/ets2-tool/src-tauri/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "ets2-tool"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "anyhow",
  "argon2",

--- a/ets2-tool/src-tauri/Cargo.toml
+++ b/ets2-tool/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ets2-tool"
-version = "0.9.5"
+version = "0.9.6"
 description = "Save-Edit Tool for ETS2"
 authors = ["xLieferant"]
 edition = "2024"

--- a/ets2-tool/src-tauri/src/features/vehicles/editor.rs
+++ b/ets2-tool/src-tauri/src/features/vehicles/editor.rs
@@ -196,19 +196,63 @@ fn validate_job_weight(mass: f32) -> Result<f32, String> {
     Ok(mass)
 }
 
-fn get_player_vehicle_id(content: &str, vehicle_type: &str) -> Result<String, String> {
-    let regex_str = format!(
-        r"player\s*:\s*[A-Za-z0-9._]+\s*\{{\s*[^}}]*?{}\s*:\s*([A-Za-z0-9._]+)",
-        vehicle_type
-    );
-    let re = cragex(&regex_str).map_err(|e| format!("Regex Fehler: {}", e))?;
-    re.captures(content)
-        .and_then(|c| c.get(1))
-        .map(|m| m.as_str().to_string())
-        .ok_or_else(|| format!("{} nicht gefunden", vehicle_type))
+/// Liest die ID des `economy.player`-Verweises. Eigenständige, minimale Implementierung
+/// (statt eines Imports aus einem anderen Parser-Modul), damit dieses Modul unabhängig bleibt.
+fn get_player_id(content: &str) -> Option<String> {
+    let mut in_economy = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("economy :") {
+            in_economy = true;
+        }
+        if in_economy && trimmed.starts_with("player:") {
+            return trimmed.split_whitespace().nth(1).map(|s| s.to_string());
+        }
+        if in_economy && trimmed.starts_with('}') {
+            in_economy = false;
+        }
+    }
+    None
 }
 
-// ← NEW: Extract complete vehicle/trailer block with proper brace matching
+/// Findet die ID des Spieler-Fahrzeugs (Truck oder Trailer).
+///
+/// WICHTIG: `player.my_truck` / `player.my_trailer` sind in aktuellen ETS2-Saves
+/// praktisch immer `null` (siehe Logs: `player_my_truck: null, player_my_trailer: null`).
+/// Die verlässliche Quelle ist stattdessen:
+///   player.assigned_vehicles → player_vehicles-Block → `vehicle:`-/`trailer:`-Feld
+///
+/// `player_field` bestimmt NUR noch, ob Truck ("vehicle") oder Trailer ("trailer")
+/// gewünscht ist – über die Werte "my_truck" / "my_trailer", wie an den Call-Sites üblich.
+fn get_player_vehicle_id(content: &str, player_field: &str) -> Result<String, String> {
+    let target_key = match player_field {
+        "my_truck" => "vehicle",
+        "my_trailer" => "trailer",
+        other => other, // Fallback: falls direkt "vehicle"/"trailer" übergeben wird
+    };
+
+    let player_id = get_player_id(content).ok_or_else(|| "player_not_found".to_string())?;
+
+    let (player_start, player_end) = extract_vehicle_block(content, "player", &player_id)
+        .map_err(|_| "player_block_not_found".to_string())?;
+    let player_block = &content[player_start..player_end];
+
+    let assigned_vehicles_id = extract_field_value(player_block, "assigned_vehicles")
+        .filter(|value| !is_null_ref(value))
+        .ok_or_else(|| "assigned_vehicles_not_found".to_string())?;
+
+    let (pv_start, pv_end) =
+        extract_vehicle_block(content, "player_vehicles", &assigned_vehicles_id)
+            .map_err(|_| "player_vehicles_block_not_found".to_string())?;
+    let pv_block = &content[pv_start..pv_end];
+
+    extract_field_value(pv_block, target_key)
+        .filter(|value| !is_null_ref(value))
+        .ok_or_else(|| format!("{} nicht gefunden", player_field))
+}
+
+// Extract complete vehicle/trailer/player/player_vehicles block with proper brace matching.
+// Generic über block_type, funktioniert daher auch für "player" und "player_vehicles".
 fn extract_vehicle_block(
     content: &str,
     block_type: &str,
@@ -275,7 +319,6 @@ where
     let (content, path) = read_save_content(profile_state.clone(), decrypt_cache.clone())?;
     let vehicle_id = get_player_vehicle_id(&content, player_vehicle_key)?;
 
-    // ← CHANGED: Use proper brace matching
     let (block_start, block_end) = extract_vehicle_block(&content, unit_type, &vehicle_id)?;
     let block = &content[block_start..block_end];
 
@@ -412,7 +455,6 @@ pub async fn repair_player_truck(
     let (content, path) = read_save_content(profile_state.clone(), decrypt_cache.clone())?;
     let truck_id = get_player_vehicle_id(&content, "my_truck")?;
 
-    // ← CHANGED: Use proper brace matching
     let (block_start, block_end) = extract_vehicle_block(&content, "vehicle", &truck_id)?;
     let mut block = content[block_start..block_end].to_string();
 
@@ -602,7 +644,6 @@ pub async fn repair_player_trailer(
 
     dev_log!("Found trailer ID: {}", trailer_id);
 
-    // ← CHANGED: Use proper brace matching to get complete block
     let (block_start, block_end) = extract_vehicle_block(&content, "trailer", &trailer_id)?;
     let mut block = content[block_start..block_end].to_string();
 
@@ -739,6 +780,61 @@ trailer : _nameless.trailer.company {
 }
 }
 "#
+    }
+
+    fn truck_fixture() -> &'static str {
+        r#"SiiNunit
+{
+economy : _nameless.economy {
+ player: _nameless.player
+}
+player : _nameless.player {
+ assigned_vehicles: _nameless.assigned.1
+ my_truck: null
+ my_trailer: null
+}
+player_vehicles : _nameless.assigned.1 {
+ vehicle: _nameless.truck.active
+ trailer: _nameless.trailer.active
+}
+vehicle : _nameless.truck.active {
+ fuel_relative: &3edf8ac0
+ engine_wear: &3be51ba8
+ odometer: 574021
+}
+trailer : _nameless.trailer.active {
+ license_plate: "ACTIVE|germany"
+}
+}
+"#
+    }
+
+    #[test]
+    fn resolves_player_truck_id_via_assigned_vehicles() {
+        assert_eq!(
+            get_player_vehicle_id(truck_fixture(), "my_truck").unwrap(),
+            "_nameless.truck.active"
+        );
+    }
+
+    #[test]
+    fn resolves_player_trailer_id_via_assigned_vehicles() {
+        assert_eq!(
+            get_player_vehicle_id(truck_fixture(), "my_trailer").unwrap(),
+            "_nameless.trailer.active"
+        );
+    }
+
+    #[test]
+    fn rejects_truck_id_when_assigned_vehicles_is_null() {
+        let fixture = truck_fixture().replace(
+            "assigned_vehicles: _nameless.assigned.1",
+            "assigned_vehicles: null",
+        );
+        assert_eq!(
+            get_player_vehicle_id(&fixture, "my_truck").unwrap_err(),
+            "assigned_vehicles_not_found"
+        );
     }
 
     #[test]

--- a/ets2-tool/src-tauri/src/features/vehicles/trucks.rs
+++ b/ets2-tool/src-tauri/src/features/vehicles/trucks.rs
@@ -90,7 +90,7 @@ pub async fn get_player_truck(
             .ok_or("Player ID nicht im economy block gefunden".to_string())?;
         let (player_truck_id_opt, _) = get_vehicle_ids(&content, &player_id);
         let player_truck_id =
-            player_truck_id_opt.ok_or("my_truck nicht im player block gefunden".to_string())?;
+            player_truck_id_opt.ok_or("assigned_vehicles/player_vehicles.vehicle nicht gefunden".to_string())?;
         let id_clean = player_truck_id.trim().to_lowercase();
         let base_truck = trucks
             .iter()
@@ -110,36 +110,25 @@ pub async fn get_player_truck(
 #[cfg(test)]
 mod tests {
     use super::player_truck_from_content;
-    use crate::shared::sii_parser::{get_vehicle_ids, parse_trucks_from_sii};
+    use crate::shared::sii_parser::parse_trucks_from_sii;
 
     #[test]
-    fn vehicle_ids_returns_truck_then_trailer() {
+    fn get_all_trucks_player_resolution_uses_assigned_vehicles_chain() {
         let content = r#"SiiNunit
 {
 economy : _nameless.economy {
  player: _nameless.player
 }
 player : _nameless.player {
- my_truck: _nameless.truck.active
- my_trailer: _nameless.trailer.attached
+ my_vehicles_mode: truck
+ assigned_vehicles_mode: truck
+ assigned_vehicles: _nameless.pv1
+ my_truck: null
+ my_trailer: null
 }
-}
-"#;
-        let ids = get_vehicle_ids(content, "_nameless.player");
-        assert_eq!(ids.0.as_deref(), Some("_nameless.truck.active"));
-        assert_eq!(ids.1.as_deref(), Some("_nameless.trailer.attached"));
-    }
-
-    #[test]
-    fn get_all_trucks_player_resolution_uses_truck_id_not_trailer_id() {
-        let content = r#"SiiNunit
-{
-economy : _nameless.economy {
- player: _nameless.player
-}
-player : _nameless.player {
- my_truck: _nameless.truck.active
- my_trailer: _nameless.truck.trailer_like
+player_vehicles : _nameless.pv1 {
+ vehicle: _nameless.truck.active
+ trailer: _nameless.trailer.attached
 }
 vehicle : _nameless.truck.active {
  accessories: 1
@@ -147,13 +136,6 @@ vehicle : _nameless.truck.active {
 }
 vehicle_accessory : _nameless.acc.active {
  data_path: "/def/vehicle/truck/scania.s_2016/data.sii"
-}
-vehicle : _nameless.truck.trailer_like {
- accessories: 1
- accessories[0]: _nameless.acc.trailer_like
-}
-vehicle_accessory : _nameless.acc.trailer_like {
- data_path: "/def/vehicle/truck/man.tgx/data.sii"
 }
 }
 "#;

--- a/ets2-tool/src-tauri/src/shared/sii_parser.rs
+++ b/ets2-tool/src-tauri/src/shared/sii_parser.rs
@@ -126,7 +126,7 @@ fn extract_combined_float(block: &str, key_base: &str) -> f32 {
     val_base + val_float
 }
 
-// ← NEW: Helper function to extract blocks with proper brace matching
+// Helper function to extract blocks with proper brace matching
 fn extract_blocks_with_braces(content: &str, block_type: &str) -> Vec<(String, String)> {
     let mut blocks = Vec::new();
     let start_pattern = format!(r"{}\s*:\s*([a-zA-Z0-9._]+)\s*\{{", block_type);
@@ -158,6 +158,41 @@ fn extract_blocks_with_braces(content: &str, block_type: &str) -> Vec<(String, S
     }
 
     blocks
+}
+
+/// Extrahiert einen einzelnen, namentlich referenzierten Block (z.B. "player : _nameless.xyz { ... }")
+/// mittels korrektem Brace-Matching. Nötig, weil einzelne Blöcke (player, player_vehicles, vehicle)
+/// gezielt über ihre ID aufgelöst werden müssen, statt nur "irgendein Block dieses Typs".
+fn extract_named_block<'a>(content: &'a str, block_type: &str, id: &str) -> Option<&'a str> {
+    let start_pattern = format!(
+        r"{}\s*:\s*{}\s*\{{",
+        regex::escape(block_type),
+        regex::escape(id)
+    );
+    let re_start = compile_regex(&start_pattern, "extract_named_block")?;
+    let block_match = re_start.find(content)?;
+    let start_pos = block_match.end();
+    let end_pos = find_matching_block_end(content, start_pos)?;
+    Some(&content[start_pos..end_pos])
+}
+
+/// Liest den Wert eines simplen "key: value"-Feldes direkt im übergebenen Block
+/// (nicht rekursiv in Unterblöcke). Gibt None zurück, wenn der Key fehlt oder der Wert "null" ist.
+/// Nutzt Zeilen-Matching mit ":" direkt nach dem Key, damit z.B. "vehicle:" nicht mit
+/// "stored_vehicle_placement:" kollidiert.
+fn extract_field_value(block: &str, key: &str) -> Option<String> {
+    let prefix = format!("{}:", key);
+    for line in block.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix(&prefix) {
+            let value = rest.trim().split_whitespace().next()?.to_string();
+            if value == "null" || value.is_empty() {
+                return None;
+            }
+            return Some(value);
+        }
+    }
+    None
 }
 
 /// Parsen von Trucks aus SII-Dateien
@@ -201,7 +236,6 @@ pub fn parse_trucks_from_sii(content: &str) -> Vec<ParsedTruck> {
         }
     }
 
-    // ← CHANGED: Use new brace-matching function
     let vehicle_blocks = extract_blocks_with_braces(content, "vehicle");
 
     for (truck_id, block) in vehicle_blocks {
@@ -289,7 +323,6 @@ pub fn parse_trucks_from_sii(content: &str) -> Vec<ParsedTruck> {
 pub fn parse_trailer_defs_from_sii(content: &str) -> HashMap<String, TrailerDefData> {
     let mut defs = HashMap::new();
 
-    // ← CHANGED: Use new brace-matching function
     let def_blocks = extract_blocks_with_braces(content, "trailer_def");
 
     for (id, block) in def_blocks {
@@ -346,7 +379,6 @@ pub fn parse_trailers_from_sii(text: &str) -> Vec<TrailerData> {
         return trailers;
     };
 
-    // ← CHANGED: Use new brace-matching function
     let trailer_blocks = extract_blocks_with_braces(text, "trailer");
 
     for (trailer_id, body) in trailer_blocks {
@@ -435,29 +467,39 @@ pub fn get_player_id(content: &str) -> Option<String> {
     None
 }
 
+/// Löst Truck- und Trailer-ID des Spielers auf.
+///
+/// WICHTIG: `player.assigned_vehicles` zeigt NICHT direkt auf einen `vehicle`-Block,
+/// sondern auf einen `player_vehicles`-Container. Der eigentliche Truck steckt erst
+/// in dessen `vehicle:`-Feld, der Trailer in dessen `trailer:`-Feld.
+/// `player.my_truck` / `player.my_trailer` sind in aktuellen Saves oft `null` und
+/// dürfen nicht als primäre Quelle verwendet werden.
 pub fn get_vehicle_ids(content: &str, player_id: &str) -> (Option<String>, Option<String>) {
-    let mut in_player = false;
-    let mut truck_id = None;
-    let mut trailer_id = None;
+    let Some(player_block) = extract_named_block(content, "player", player_id) else {
+        dev_log!(
+            "[sii_parser] player block for {} not found",
+            player_id
+        );
+        return (None, None);
+    };
 
-    let player_block_start = format!("player : {}", player_id);
+    let assigned_vehicles_ref = extract_field_value(player_block, "assigned_vehicles");
 
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with(&player_block_start) {
-            in_player = true;
-        }
-        if in_player {
-            if trimmed.starts_with("my_truck:") {
-                truck_id = trimmed.split_whitespace().nth(1).map(|s| s.to_string());
-            }
-            if trimmed.starts_with("my_trailer:") {
-                trailer_id = trimmed.split_whitespace().nth(1).map(|s| s.to_string());
-            }
-            if trimmed.starts_with("}") {
-                break;
-            }
-        }
-    }
+    let Some(pv_id) = assigned_vehicles_ref else {
+        dev_log!("[sii_parser] player {} has no assigned_vehicles", player_id);
+        return (None, None);
+    };
+
+    let Some(pv_block) = extract_named_block(content, "player_vehicles", &pv_id) else {
+        dev_log!(
+            "[sii_parser] player_vehicles block {} not found",
+            pv_id
+        );
+        return (None, None);
+    };
+
+    let truck_id = extract_field_value(pv_block, "vehicle");
+    let trailer_id = extract_field_value(pv_block, "trailer");
+
     (truck_id, trailer_id)
 }

--- a/ets2-tool/src-tauri/tauri.conf.json
+++ b/ets2-tool/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2.0/schema.json",
 
   "productName": "Save-Edit Tool xLieferant",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "identifier": "com.xlieferant.saveedittool",
 
   "build": {


### PR DESCRIPTION
Bump package version to 0.9.6 (Cargo.toml, Cargo.lock, tauri.conf.json). Add robust brace-matching and field-extraction helpers to improve resolving player vehicle IDs: introduce get_player_id, extract_named_block, extract_field_value and use the assigned_vehicles → player_vehicles → vehicle|trailer chain instead of relying on my_truck/my_trailer. Update get_vehicle_ids and get_player_vehicle_id to use the new logic and return clearer errors when assigned_vehicles is missing or null. Adjust tests in vehicles/editor.rs and vehicles/trucks.rs to cover the new resolution path and update error messages accordingly.

close #95 